### PR TITLE
Remove comment-based generic syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Stop using comment-based generics.
+
 ## 1.0.2
 
 * Declare support for `async` 2.0.0.

--- a/lib/src/pattern_descriptor.dart
+++ b/lib/src/pattern_descriptor.dart
@@ -60,7 +60,7 @@ class PatternDescriptor extends Descriptor {
     var results = await Future.wait(matchingEntries.map((entry) {
       var basename = p.basename(entry);
       return runZoned(() {
-        return Result.capture/*<String>*/(new Future.sync(() async {
+        return Result.capture(new Future.sync(() async {
           await _fn(basename).validate(parent);
           return basename;
         }));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: test_descriptor
-version: 1.0.2
+version: 1.0.3
 description: An API for defining and verifying directory structures.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/test_descriptor
 
 environment:
-  sdk: '>=1.8.0 <2.0.0'
+  sdk: '>=1.21.0 <2.0.0'
 
 dependencies:
   async: '>=1.10.0 <3.0.0'


### PR DESCRIPTION
It looks like this explicit generic wasn't necessary anymore anyway.

Closes dart-lang/test#2436