### PR TITLE
Fix dart:convert "UTF8" -> "utf8".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: dart
 
 dart:
   - dev
-  - stable
 
 dart_task:
   - test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+* Update to lowercase Dart core library constants.
+
 ## 1.1.0
 
 * Add a `path()` function that returns the a path within the sandbox directory.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,0 @@
-analyzer:
-  strong-mode: true

--- a/lib/src/file_descriptor.dart
+++ b/lib/src/file_descriptor.dart
@@ -38,7 +38,7 @@ abstract class FileDescriptor extends Descriptor {
   factory FileDescriptor(String name, contents) {
     if (contents is String) return new _StringFileDescriptor(name, contents);
     if (contents is List) {
-      return new _BinaryFileDescriptor(name, DelegatingList.typed(contents));
+      return new _BinaryFileDescriptor(name, contents.cast<int>());
     }
     if (contents == null) return new _BinaryFileDescriptor(name, []);
     return new _MatcherFileDescriptor(name, contents);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: test_descriptor
-version: 1.1.0
+version: 1.1.1
 description: An API for defining and verifying directory structures.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/test_descriptor
 
 environment:
-  sdk: '>=1.21.0 <2.0.0'
+  sdk: '>=2.0.0-dev.36.0 <3.0.0'
 
 dependencies:
   async: '>=1.10.0 <3.0.0'

--- a/test/directory_test.dart
+++ b/test/directory_test.dart
@@ -136,7 +136,7 @@ void main() {
     test("loads a file", () {
       var dir = d.dir('dir',
           [d.file('name.txt', 'contents'), d.file('other.txt', 'wrong')]);
-      expect(UTF8.decodeStream(dir.load('name.txt')),
+      expect(utf8.decodeStream(dir.load('name.txt')),
           completion(equals('contents')));
     });
 
@@ -148,7 +148,7 @@ void main() {
         d.file('name.txt', 'contents')
       ]);
 
-      expect(UTF8.decodeStream(dir.load('subdir/name.txt')),
+      expect(utf8.decodeStream(dir.load('subdir/name.txt')),
           completion(equals('subcontents')));
     });
 
@@ -206,7 +206,7 @@ void main() {
       ]);
 
       expect(
-          UTF8.decodeStream(dir.load('name')), completion(equals('contents')));
+          utf8.decodeStream(dir.load('name')), completion(equals('contents')));
     });
   });
 

--- a/test/file_test.dart
+++ b/test/file_test.dart
@@ -139,7 +139,7 @@ void main() {
 
     test("readAsBytes() returns the contents of a text file as a byte stream",
         () {
-      expect(UTF8.decodeStream(d.file('name.txt', 'contents').readAsBytes()),
+      expect(utf8.decodeStream(d.file('name.txt', 'contents').readAsBytes()),
           completion(equals('contents')));
     });
 

--- a/test/sandbox_test.dart
+++ b/test/sandbox_test.dart
@@ -4,16 +4,12 @@
 
 @TestOn('vm')
 
-import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'package:test_descriptor/test_descriptor.dart' as d;
-
-import 'utils.dart';
 
 void main() {
   test("accessing the getter creates the directory", () {


### PR DESCRIPTION
While I was at it, I:

- Removed some unused imports.
- Fixed a deprecated API call.
- Removed the no-longer needed analysis options file.