### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/src/descriptor.dart
+++ b/lib/src/descriptor.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'sandbox.dart';
 
 /// A declarative description of a filesystem entry.

--- a/lib/src/nothing_descriptor.dart
+++ b/lib/src/nothing_descriptor.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported by dart:core