### PR TITLE
Migrate to runZonedGuarded

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 
 dart:
   - dev
-  - 2.7.0
+  - 2.8.0
 
 dart_task:
   - test
@@ -14,7 +14,7 @@ matrix:
   - dart: dev
     dart_task:
       dartanalyzer: --fatal-infos --fatal-warnings .
-  - dart: 2.7.0
+  - dart: 2.8.0
     dart_task:
       dartanalyzer: --fatal-warnings .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: dart
 
 dart:
   - dev
-  - 2.8.0
+  - 2.8.1
 
 dart_task:
   - test
@@ -14,7 +14,7 @@ matrix:
   - dart: dev
     dart_task:
       dartanalyzer: --fatal-infos --fatal-warnings .
-  - dart: 2.8.0
+  - dart: 2.8.1
     dart_task:
       dartanalyzer: --fatal-warnings .
 

--- a/lib/src/pattern_descriptor.dart
+++ b/lib/src/pattern_descriptor.dart
@@ -59,12 +59,12 @@ class PatternDescriptor extends Descriptor {
 
     var results = await Future.wait(matchingEntries.map((entry) {
       var basename = p.basename(entry);
-      return runZoned(() {
+      return runZonedGuarded(() {
         return Result.capture(Future.sync(() async {
           await _fn(basename).validate(parent);
           return basename;
         }));
-      }, onError: (_) {
+      }, (_, __) {
         // Validate may produce multiple errors, but we ignore all but the first
         // to avoid cluttering the user with many different errors from many
         // different un-matched entries.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: An API for defining and verifying directory structures.
 homepage: https://github.com/dart-lang/test_descriptor
 
 environment:
-  sdk: '>=2.8.0 <3.0.0'
+  sdk: '>=2.8.1 <3.0.0'
 
 dependencies:
   archive: '^2.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: An API for defining and verifying directory structures.
 homepage: https://github.com/dart-lang/test_descriptor
 
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.8.0 <3.0.0'
 
 dependencies:
   archive: '^2.0.0'

--- a/test/directory_test.dart
+++ b/test/directory_test.dart
@@ -103,7 +103,7 @@ void main() {
 
       var errors = 0;
       var controller = StreamController<String>();
-      runZoned(() {
+      runZonedGuarded(() {
         d.dir('dir', [
           d.dir('subdir', [
             d.file('subfile1.txt', 'subcontents1'),
@@ -113,7 +113,7 @@ void main() {
           d.file('file2.txt', 'contents2')
         ]).validate();
       },
-          onError: expectAsync1((error) {
+          expectAsync2((error, _) {
             errors++;
             controller.add(error.toString());
             if (errors == 3) controller.close();


### PR DESCRIPTION
The `onError` argument to `runZoned` is deprecated. Switch to the
supported `runZonedGuarded`. Add ignored parameters for the `StackTrace`
argument to fit the more strict static type.

Bump min SDK to 2.8.0 which added the `runZonedGuarded` API.