### PR TITLE
clean up some apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Migrate to null safety.
 * Fix outdated URLs in `README.md`.
 * BREAKING: Removed archive support.
+* BREAKING: `DirectoryDescriptor.load` only supports a `String` path instead of
+  also accepting relative `Uri` objects.
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * BREAKING: Removed archive support.
 * BREAKING: `DirectoryDescriptor.load` only supports a `String` path instead of
   also accepting relative `Uri` objects.
+* BREAKING: `DirectoryDescriptor.load` no longer has an optional `parents`
+  parameter - this was intended for internal use only.
 
 ## 1.2.0
 

--- a/lib/src/directory_descriptor.dart
+++ b/lib/src/directory_descriptor.dart
@@ -74,25 +74,15 @@ class DirectoryDescriptor extends Descriptor {
   }
 
   /// Treats this descriptor as a virtual filesystem and loads the binary
-  /// contents of the [FileDescriptor] at the given relative [url], which may be
-  /// a [Uri] or a [String].
+  /// contents of the [FileDescriptor] at the given relative [path].
   ///
   /// The [parents] parameter should only be passed by subclasses of
   /// [DirectoryDescriptor] that are recursively calling [load]. It's the
   /// URL-format path of the directories that have been loaded so far.
-  Stream<List<int>> load(url, [String? parents]) {
-    String path;
-    if (url is String) {
-      path = url;
-    } else if (url is Uri) {
-      path = url.toString();
-    } else {
-      throw ArgumentError.value(url, 'url', 'must be a Uri or a String.');
-    }
-
+  Stream<List<int>> load(String path, [String? parents]) {
     if (!p.url.isWithin('.', path)) {
       throw ArgumentError.value(
-          url, 'url', 'must be relative and beneath the base URL.');
+          path, 'path', 'must be relative and beneath the base URL.');
     }
 
     return StreamCompleter.fromFuture(Future.sync(() {

--- a/lib/src/directory_descriptor.dart
+++ b/lib/src/directory_descriptor.dart
@@ -75,11 +75,10 @@ class DirectoryDescriptor extends Descriptor {
 
   /// Treats this descriptor as a virtual filesystem and loads the binary
   /// contents of the [FileDescriptor] at the given relative [path].
-  ///
-  /// The [parents] parameter should only be passed by subclasses of
-  /// [DirectoryDescriptor] that are recursively calling [load]. It's the
-  /// URL-format path of the directories that have been loaded so far.
-  Stream<List<int>> load(String path, [String? parents]) {
+  Stream<List<int>> load(String path) => _load(path);
+
+  /// Implementation of [load], tracks parents through recursive calls.
+  Stream<List<int>> _load(String path, [String? parents]) {
     if (!p.url.isWithin('.', path)) {
       throw ArgumentError.value(
           path, 'path', 'must be relative and beneath the base URL.');
@@ -107,7 +106,7 @@ class DirectoryDescriptor extends Descriptor {
           return (matchingEntries.first as FileDescriptor).readAsBytes();
         } else {
           return (matchingEntries.first as DirectoryDescriptor)
-              .load(p.url.joinAll(remainingPath), parentsAndSelf);
+              ._load(p.url.joinAll(remainingPath), parentsAndSelf);
         }
       }
     }));

--- a/lib/src/file_descriptor.dart
+++ b/lib/src/file_descriptor.dart
@@ -35,7 +35,7 @@ abstract class FileDescriptor extends Descriptor {
   ///
   /// To match a [Matcher] against a file's binary contents, use [new
   /// FileDescriptor.binaryMatcher] instead.
-  factory FileDescriptor(String name, contents) {
+  factory FileDescriptor(String name, Object? contents) {
     if (contents is String) return _StringFileDescriptor(name, contents);
     if (contents is List) {
       return _BinaryFileDescriptor(name, contents.cast<int>());


### PR DESCRIPTION
- drop support for Uri objects in DirectoryDescriptor.load
- Use Object? instead of dynamic for `FileDescriptor` contents parameter
- Remove `parents` param in DirectoryDescriptor.load