### PR TITLE
Remove unused dart:async imports.

### DIFF
--- a/lib/src/directory_descriptor.dart
+++ b/lib/src/directory_descriptor.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:async/async.dart';

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 
 import 'package:path/path.dart' as p;

--- a/test/utils.dart
+++ b/test/utils.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:test/test.dart';
 
 /// Converts a [Stream<List<int>>] to a flat byte future.


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.