### PR TITLE
Move TestOn annotation to library level

### DIFF
--- a/test/file_test.dart
+++ b/test/file_test.dart
@@ -2,8 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
 @TestOn('vm')
+
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;


### PR DESCRIPTION
These annotations are only read at the library level. The next version
of the test package configures the `Target` for this annotation so the
analyzer will raise diagnostics for these incorrect usages.